### PR TITLE
build: Enable A53 errata workarounds on targets that need it

### DIFF
--- a/core/combo/arch/arm64/armv8-a.mk
+++ b/core/combo/arch/arm64/armv8-a.mk
@@ -1,5 +1,12 @@
 arch_variant_cflags :=
 
+# If the chip uses a53 cores, enable the errata workarounds
+ifneq ($(filter $(TARGET_CPU_VARIANT) $(TARGET_2ND_CPU_VARIANT),cortex-a53),)
+    TARGET_CPU_CORTEX_A53 ?= true
+endif
+
+# Leave the flag so devices that need the workaround but don't fit in
+# the check above can still enable it.
 ifeq ($(TARGET_CPU_CORTEX_A53),true)
 arch_variant_ldflags := -Wl,--fix-cortex-a53-843419 \
                         -Wl,--fix-cortex-a53-835769


### PR DESCRIPTION
 * Automatically enable the errata workarounds on 64bit chips using A53 cores
 * Leave the TARGET_CPU_CORTEX_A53 flag in case a device that needs these
   workarounds has side effects from setting the CPU variant.

Change-Id: I86917fc70445fef442226e6128c361f836bae755